### PR TITLE
Inherit constructor argument types from `mysqli`

### DIFF
--- a/src/MySQL.php
+++ b/src/MySQL.php
@@ -3,7 +3,13 @@
 	namespace libmysqldriver;
 
 	class MySQL extends \mysqli {
-		function __construct(string $host, string $user, string $pass, string $db) {
+		function __construct(
+			// From: https://www.php.net/manual/en/mysqli.construct.php
+			string|null $host = null,
+			string|null $user = null,
+			string|null $pass = null,
+			string|null $db = null
+		) {
 			parent::__construct($host, $user, $pass, $db);
 		}
 


### PR DESCRIPTION
There is no reason why this lib should have type requirements when mysqli will connect with default paramteres if `null` is passed to any of its arguments

```php
public mysqli::__construct(
    ?string $hostname = null,
    ?string $username = null,
    ?string $password = null,
    ?string $database = null,
    ?int $port = null,
    ?string $socket = null
)
```
From: https://www.php.net/manual/en/mysqli.construct.php