### PR TITLE
Accept CSV string as columns for `select()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ $db = new MySQL($host, $user, $pass, $db);
 
 # SELECT
 
-Use `MySQL->select()` to retrieve columns from a database table
+Use `MySQL->select()` to retrieve columns from a database table.
+
+Pass an associative array of strings, CSV string, or null to this method to filter columns.
 
 ```php
 $db->select(
-  // Sequential array of string with column names to retrieve
-  // Or null to retrieve a bool if rows were matched
-  ?array $columns
+  array|string|null $columns
 ): array|bool;
 // Returns array of arrays for each row, or bool if no columns were defined
 ```
@@ -75,6 +75,7 @@ In most cases you probably want to select with a constraint. Chain the [`where()
 ### Example
 ```php
 $beverages = $db->for("beverages")->select(["beverage_name", "beverage_size"]); // SELECT beverage_name, beverage_size FROM beverages
+$beverages = $db->for("beverages")->select("beverage_name, beverage_size"); // SELECT beverage_name, beverage_size FROM beverages
 ```
 ```
 [

--- a/src/MySQL.php
+++ b/src/MySQL.php
@@ -136,8 +136,11 @@
 		/* ---- */
 
 		// Create Prepared Statament for SELECT with optional WHERE filters
-		public function select(?array $columns = null): array|bool {
+		public function select(array|string|null $columns = null): array|bool {
 			$this->throw_if_no_table();
+
+			// Create array of columns from CSV
+			$columns = is_array($columns) ? $columns : explode(",", $columns);
 
 			// Filter columns that aren't in the model if defiend
 			if ($columns && $this->model) {


### PR DESCRIPTION
This PR adds support for CSV `string`s in `MySQL->select()`. Table model (`MySQL->with()`) constraints are still enforced on strings if one has been defined.