### PR TITLE
Array type coercion for params in `DatabaseDriver`

### DIFF
--- a/src/DatabaseDriver.php
+++ b/src/DatabaseDriver.php
@@ -13,9 +13,14 @@
 			parent::__construct(...func_get_args());
 		}
 
+		// Coerce input to array
+		private static function to_array(mixed $input): array {
+			return is_array($input) ? $input : [$input];
+		}
+
 		// Execute SQL query with optional prepared statement and return array of affected rows
 		public function exec(string $sql, mixed $params = null): array {
-			$query = $this->execute_query($sql, $params);
+			$query = $this->execute_query($sql, self::to_array($params));
 			$res = [];
 
 			// Fetch rows into sequential array
@@ -28,7 +33,7 @@
 
 		// Execute SQL query with optional prepared statement and return true if query was successful
 		public function exec_bool(string $sql, mixed $params = null): bool {
-			$query = $this->execute_query($sql, $params);
+			$query = $this->execute_query($sql, self::to_array($params));
 
 			return gettype($query) === "boolean"
 				// Type is already a bool, so return it as is


### PR DESCRIPTION
If the $param passed to `DatabaseDriver->exec()` or `DatabaseDriver->exec_bool()` is anything but an array, `execute_query()` will not accept it. This PR coerces any type to an array before passing it to execute_query.