### PR TITLE
Fix issue with filter value `null` in `where()` method

### DIFF
--- a/src/MySQL.php
+++ b/src/MySQL.php
@@ -91,6 +91,12 @@
 						continue;
 					}
 
+					// Value is null so it does not need to be added to the prepared statement
+					if (is_null($value)) {
+						$filter[] = "`{$col}` IS NULL";
+						continue;
+					}
+
 					// Create SQL for prepared statement
 					$filter[] = "`{$col}` = ?";
 					// Append value to array with all other values


### PR DESCRIPTION
Fixed an issue where passing a filter with value `null` to `where()` did not filter on anything, when it should filter on columns where the value equals `NULL` in the database.