### PR TITLE
Fix return types for executor methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ use libmysqldriver\MySQL;
 $db = new MySQL($host, $user, $pass, $db);
 ```
 
-All executor methods [`select()`](#select), [`update()`](#update), and [`insert()`](#insert) will return a [`mysqli_result`](https://www.php.net/manual/en/class.mysqli-result.php) object.
+All executor methods [`select()`](#select), [`update()`](#update), and [`insert()`](#insert) will return a [`mysqli_result`](https://www.php.net/manual/en/class.mysqli-result.php) object or boolean.
 
 # SELECT
 
@@ -69,7 +69,7 @@ Pass an associative array of strings, CSV string, or null to this method to filt
 ```php
 $db->select(
   array|string|null $columns
-): mysqli_result;
+): mysqli_result|bool;
 ```
 
 In most cases you probably want to select with a constraint. Chain the [`where()`](#where) method before `select()` to filter the query
@@ -119,7 +119,7 @@ Use `MySQL->insert()` to append a new row to a database table
 $db->insert(
   // Array of values to INSERT
   array $values
-): mysqli_result
+): mysqli_result|bool
 // Returns true if row was inserted
 ```
 
@@ -146,7 +146,7 @@ Modify existing rows with `MySQL->update()`
 $db->get(
   // Key, value array of column names and values to update
   array $fields,
-): mysqli_result;
+): mysqli_result|bool;
 // Returns true if at least 1 row was changed
 ```
 

--- a/src/MySQL.php
+++ b/src/MySQL.php
@@ -173,7 +173,7 @@
 		*/
 
 		// Create Prepared Statament for SELECT with optional WHERE filters
-		public function select(array|string|null $columns = null): mysqli_result {
+		public function select(array|string|null $columns = null): mysqli_result|bool {
 			$this->throw_if_no_table();
 
 			// Create array of columns from CSV
@@ -206,7 +206,7 @@
 		}
 
 		// Create Prepared Statement for UPDATE using PRIMARY KEY as anchor
-		public function update(array $entity): mysqli_result {
+		public function update(array $entity): mysqli_result|bool {
 			$this->throw_if_no_table();
 
 			// Make constraint for table model if defined
@@ -238,7 +238,7 @@
 		}
 
 		// Create Prepared Statemt for INSERT
-		public function insert(array $values): mysqli_result {
+		public function insert(array $values): mysqli_result|bool {
 			$this->throw_if_no_table();
 
 			// A value for each column in table model must be provided


### PR DESCRIPTION
MySQLi `execute_query()` can also return a boolean, fixed the return types for executor methods