### PR TITLE
Second argument instead of array for `LIMIT``OFFSET`

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,10 +5,10 @@ This library provides abstraction methods for common operations on MySQL-like da
 For example:
 ```php
 MySQL->for(string $table)
-  ->with(array $model)
-  ->where(array $filters)
-  ->order(array $order_by)
-  ->limit(int|array $limit)
+  ->with(?array $model)
+  ->where(?array ...$conditions)
+  ->order(?array $order_by)
+  ->limit(int|array|null $limit)
   ->select(array $columns): array|bool;
 ```
 which would be equivalent to the following in MySQL:
@@ -142,7 +142,7 @@ true
 Modify existing rows with `MySQL->update()`
 
 ```php
-MySQL->get(
+MySQL->update(
   // Key, value array of column names and values to update
   array $fields,
 ): mysqli_result|bool;
@@ -163,6 +163,12 @@ In most cases you probably want to UPDATE against a constaint. Chain a [`where()
 # WHERE
 
 Filter a `select()` or `update()` method by chaining the `MySQL->where()` method anywhere before it.
+
+```php
+MySQL->where(
+  ?array ...$conditions
+): self;
+```
 
 ### Example
 ```php
@@ -226,6 +232,12 @@ WHERE (beverage_type = 'coffee' AND beverage_size = 15) OR (beverage_type = 'tea
 Chain the `order()` method before a `select()` statement to order by a specific column
 
 ```php
+MySQL->order(
+  ?array $order_by
+): self;
+```
+
+```php
 $coffee = MySQL->for("beverages")->order(["beverage_name" => "ASC"])->select(["beverage_name", "beverage_size"]); // SELECT beverage_name, beverage_size FROM beverages ORDER BY beverage_name ASC
 ```
 ```php
@@ -245,6 +257,12 @@ $coffee = MySQL->for("beverages")->order(["beverage_name" => "ASC"])->select(["b
 # LIMIT
 
 Chain the `limit()` method before a `select()` statement to limit the amount of columns returned
+
+```php
+MySQL->limit(
+  int|array|null $limit
+): self;
+```
 
 > **Note**
 > You can also flatten to a single dimensional array from the first entity by chaining [`MySQL->flatten()`](#flatten-array-to-single-dimension)

--- a/README.md
+++ b/README.md
@@ -260,14 +260,15 @@ Chain the `limit()` method before a `select()` statement to limit the amount of 
 
 ```php
 MySQL->limit(
-  int|array|null $limit
+  ?int $limit,
+  ?int $offset = null
 ): self;
 ```
 
 > **Note**
 > You can also flatten to a single dimensional array from the first entity by chaining [`MySQL->flatten()`](#flatten-array-to-single-dimension)
 
-## Passing an integer to LIMIT
+## Passing a single integer argument
 This will simply `LIMIT` the results returned to the integer passed
 
 ```php
@@ -282,11 +283,11 @@ $coffee = MySQL->for("beverages")->limit(1)->select(["beverage_name", "beverage_
 ]
 ```
 
-## Passing an associative array to LIMIT
-This will `OFFSET` and `LIMIT` the results returned from the first key of the array as `OFFSET` and the value of that key as `LIMIT`
+## Passing two integer arguments
+This will `OFFSET` and `LIMIT` the results returned. The first argument will be the `LIMIT` and the second argument will be its `OFFSET`.
 
 ```php
-$coffee = MySQL->for("beverages")->limit([3 => 2])->select(["beverage_name", "beverage_size"]); // SELECT beverage_name, beverage_size FROM beverages LIMIT 3 OFFSET 2
+$coffee = MySQL->for("beverages")->limit(3, 2)->select(["beverage_name", "beverage_size"]); // SELECT beverage_name, beverage_size FROM beverages LIMIT 3 OFFSET 2
 ```
 ```php
 [

--- a/src/MySQL.php
+++ b/src/MySQL.php
@@ -17,7 +17,7 @@
 		private ?string $order_by = null;
 		private ?string $filter_sql = null;
 		private array $filter_values = [];
-		private int|string|null $limit = null;
+		private ?string $limit = null;
 
 		// Pass constructor arguments to driver
 		function __construct() {
@@ -151,25 +151,20 @@
 		}
 
 		// Return SQL LIMIT string from integer or array of [offset => limit]
-		public function limit(int|array|null $limit): self {
+		public function limit(?int $limit, ?int $offset = null): self {
 			// Unset row limit if null was passed
 			if ($limit === null) {
 				$this->limit = null;
 				return $this;
 			}
 
-			// Set LIMIT without range directly as integer
-			if (is_int($limit)) {
-				$this->limit = $limit;
+			// No offset defined, set limit property directly as string
+			if (is_null($offset)) {
+				$this->limit = (string) $limit;
 				return $this;
 			}
 
-			// Use array key as LIMIT range start value
-			$offset = (int) array_keys($limit)[0];
-			// Use array value as LIMIT range end value
-			$limit = (int) array_values($limit)[0];
-
-			// Set limit as SQL CSV
+			// Set limit and offset as SQL CSV
 			$this->limit = "{$offset},{$limit}";
 			return $this;
 		}

--- a/src/MySQL.php
+++ b/src/MySQL.php
@@ -94,7 +94,15 @@
 		}
 
 		// Create a WHERE statement from filters
-		public function where(array ...$conditions): self {
+		public function where(?array ...$conditions): self {
+			// Unset filters if null was passed
+			if ($conditions === null) {
+				$this->filter_sql = null;
+				$this->filter_values = null;
+
+				return $this;
+			}
+
 			$values = [];
 			$filters = [];
 
@@ -143,7 +151,13 @@
 		}
 
 		// Return SQL LIMIT string from integer or array of [offset => limit]
-		public function limit(int|array $limit): self {
+		public function limit(int|array|null $limit): self {
+			// Unset row limit if null was passed
+			if ($limit === null) {
+				$this->limit = null;
+				return $this;
+			}
+
 			// Set LIMIT without range directly as integer
 			if (is_int($limit)) {
 				$this->limit = $limit;
@@ -167,7 +181,13 @@
 		}
 
 		// Return SQL SORT BY string from assoc array of columns and direction
-		public function order(array $order_by): self {
+		public function order(?array $order_by): self {
+			// Unset row order by if null was passed
+			if ($order_by === null) {
+				$this->order_by = null;
+				return $this;
+			}
+
 			// Create CSV from columns
 			$sql = implode(",", array_keys($order_by));
 			// Create pipe DSV from values 


### PR DESCRIPTION
Removes the associative array style to set a limit offset for `MySQL->limit()`. It's now passed as an optional second argument instead.