### PR TITLE
Add executor for DELETE statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Statement|Method
 `SELECT`|[`select()`](#select)
 `UPDATE`|[`update()`](#update)
 `INSERT`|[`insert()`](#insert)
+`DELETE`|[`delete()`](#delete)
 `WHERE`|[`where()`](#where)
 `ORDER BY`|[`order()`](#order-by)
 `LIMIT`|[`limit()`](#limit)
@@ -139,6 +140,34 @@ MySQL->for("beverages")->insert([
 true
 ```
 
+# DELETE
+
+Use `MySQL->delete()` to remove a row or rows from the a database table.
+
+```php
+MySQL->delete(
+  array ...$conditions
+): mysqli_result|bool
+// Returns true if at least one row was deleted
+```
+
+This method takes at least one [`MySQL->where()`](#where)-syntaxed argument to determine which row or rows to delete. Refer to the [`MySQL->where()`](#where) section for more information.
+
+#### Example
+
+```php
+MySQL->for("beverages")->insert([
+  null,
+  "coffee",
+  "latte",
+  10
+]);
+// INSERT INTO beverages VALUES (null, "coffee", "latte", 10);
+```
+```
+true
+```
+
 # UPDATE
 
 Modify existing rows with `MySQL->update()`
@@ -164,7 +193,7 @@ In most cases you probably want to UPDATE against a constaint. Chain a [`where()
 
 # WHERE
 
-Filter a `select()` or `update()` method by chaining the `MySQL->where()` method anywhere before it.
+Filter a `select()` or `update()` method by chaining the `MySQL->where()` method anywhere before it. The `MySQL->delete()` executor method also uses the same syntax for its arguments.
 
 ```php
 MySQL->where(

--- a/src/MySQL.php
+++ b/src/MySQL.php
@@ -296,6 +296,29 @@
 			return $this->execute_query($sql, self::to_list_array($values));
 		}
 
+		// Create Prepared Statemente for DELETE with WHERE condition(s)
+		public function delete(array ...$conditions): mysqli_result|bool {
+			$this->throw_if_no_table();
+
+			// Make constraint for table model if defined
+			if ($this->model) {
+				foreach ($conditions as $condition) {
+					foreach (array_keys($condition) as $col) {
+						// Throw if column in entity does not exist in defiend table model
+						if (!in_array($col, $this->model)) {
+							throw new Exception("Column key '{$col}' does not exist in table model");
+						}
+					}
+				}
+			}
+
+			// Set DELETE WHERE conditions from arguments
+			$this->where(...$conditions);
+
+			$sql = "DELETE FROM {$this->table} WHERE {$this->filter_sql}";
+			return $this->execute_query($sql, self::to_list_array($this->filter_values));
+		}
+
 		// Execute SQL query with optional prepared statement and return mysqli_result
 		public function exec(string $sql, mixed $params = null): mysqli_result {
 			return $this->execute_query($sql, self::to_list_array($params));


### PR DESCRIPTION
Perform DELETE queries by chaining `delete()` and passing it `WHERE` conditions. See updated README for more information.