### PR TITLE
Typecast bool to tinyint in MySQL->where()

### DIFF
--- a/src/MySQL.php
+++ b/src/MySQL.php
@@ -150,7 +150,7 @@
 			// OR all filter groups
 			$this->filter_sql = implode(" OR ", $filters);
 			// Set values property
-			$this->filter_values = $values;
+			$this->filter_values = self::filter_booleans($values);
 
 			return $this;
 		}


### PR DESCRIPTION
Fixes MySQL invalid property type bug in `MySQL->where()` when a boolean is passed as a value